### PR TITLE
Do not output dbmole error report in test

### DIFF
--- a/load.php
+++ b/load.php
@@ -115,7 +115,7 @@ function dbmole_error_handler($dbmole){
 			$ATK14_LOGGER->error($dbmole->getErrorReport());
 			$ATK14_LOGGER->flush();
 		}
-	}else{
+	}elseif(!TEST){
 		echo "<pre>";
 		echo h($dbmole->getErrorReport());
 		echo "</pre>";


### PR DESCRIPTION
I dont't find any advantage for seeing this mess in console. Maybe it could be passed to $ATK14_LOGGER.
This output seems to be intended for use in development.