### PR TITLE
compatibility for both phpunit and phpunit2

### DIFF
--- a/src/atk14/tc_atk14_model.php
+++ b/src/atk14/tc_atk14_model.php
@@ -3,14 +3,11 @@ if(!class_exists("TcSuperBase")){
 	class TcSuperBase{ }
 }
 
-
 class TcAtk14Model extends TcSuperBase{
 	var $dbmole = null;
 
-	function __construct(){
-		$ref = new ReflectionClass("TcSuperBase");
-		$ref->newInstance(func_get_args());
-
+	function __construct($name = NULL, array $data = array(), $dataName = ''){
 		$this->dbmole = $GLOBALS["dbmole"];
+		parent::__construct($name, $data, $dataName);
 	}
 }

--- a/src/atk14/test/tc_model.php
+++ b/src/atk14/test/tc_model.php
@@ -1,0 +1,22 @@
+<?php
+class TcUnitBase extends TcAtk14Model {}
+
+class TcModel extends TcUnitBase {
+	/**
+	 * @dataProvider provideNumbers
+	 */
+	function testSomething($a, $b) {
+		$this->assertTrue(isset($a));
+		$this->assertTrue(isset($b));
+		$this->assertEquals(2 + $a, $b);
+	}
+
+	function provideNumbers() {
+		return array(
+			"ada" => array(0,2),
+			array(1,3),
+			array(5,7),
+		);
+	}
+}
+


### PR DESCRIPTION
With the original constructor test could not use some features available in PHPUnit, like data providers. They could not be executed through Atk14's run_unit_tests script nor using direct phpunit.
New constructor allows to run these unit tests both ways but should preserve compatibility with PHPUnit2.

Added basic test.