### PR TITLE
Removed type attribute on script tag.

### DIFF
--- a/src/atk14/helpers/function.javascript_script_tag.php
+++ b/src/atk14/helpers/function.javascript_script_tag.php
@@ -90,5 +90,5 @@ function smarty_function_javascript_script_tag($params,$template){
 
 	$attribs = Atk14Utils::JoinAttributes($params);
 	
-	return "<script src=\"$src\" type=\"text/javascript\"$attribs></script>";
+	return "<script src=\"$src\" $attribs></script>";
 }


### PR DESCRIPTION
The type attribute is unnecessary for JavaScript resources and causes a validation warning to occur on w3org HTML validator.