### PR TITLE
Fix php warning in function.render.php

### DIFF
--- a/src/atk14/helpers/function.render.php
+++ b/src/atk14/helpers/function.render.php
@@ -170,7 +170,7 @@ function smarty_function_render($params,$template){
 	$template_name = preg_replace("/([^\\/]+)$/","_\\1",$template_name);
 	$template_name .= ".tpl";
 
-	if(in_array("from",array_keys($orig_params)) && (!isset($params["from"]) || sizeof($params["from"])==0)){ return ""; }
+	if(in_array("from",array_keys($orig_params)) && (!isset($params["from"]) || (!is_numeric($params["from"]) && sizeof($params["from"])==0))){ return ""; }
 
 	$original_smarty_vars = $smarty->getTemplateVars();
 	if($solve_smarty_vs_template_problem){


### PR DESCRIPTION
Fix php warning in case $params["from"] is numeric.
According to lines 91/95 $params["from"] being numeric is a valid options. However in such case line 173 will produce a php warning.
I propose this change to get rid of it.